### PR TITLE
New debug histograms for cluster size

### DIFF
--- a/include/MuonCVXDRealDigitiser.h
+++ b/include/MuonCVXDRealDigitiser.h
@@ -173,6 +173,9 @@ protected:
     bool create_stats;
     TH1F* signal_dHisto;
     TH1F* bib_dHisto;
+    TH1F* signal_cSizeHisto;
+    TH1F* bib_cSizeHisto;
+
 };
 
 #endif //MuonCVXDRealDigitiser_h


### PR DESCRIPTION
* Added two new histograms for the size of the reco-clusters for signal and background
(a reco-cluster is considered part of the "signal" if it contains at least a signal simhit, i.e. not tagged as overlay)

* Added the list of the simhits that create the reco-cluster to the reco-cluster as "rawhits"