### PR TITLE
Fixing a bug in realistic digitization with layer ID mismatch

### DIFF
--- a/include/MuonCVXDDigitiser.h
+++ b/include/MuonCVXDDigitiser.h
@@ -168,7 +168,8 @@ protected:
     double _timeSmearingSigma;
     int _electronicEffects;
     int _produceFullPattern;
-
+    std::vector<int> _layerIDs;
+  
     MyG4UniversalFluctuationForSi *_fluctuate;
 
     // charge discretization
@@ -236,6 +237,7 @@ protected:
     void LoadGeometry();
     void PrintGeometryInfo();
     double randomTail( const double qmin, const double qmax );
+    int layerMapping( int id);
 };
 
 #endif


### PR DESCRIPTION
In MAIA and MuSIC geometries, the layers are not sequentially numbered after removing the double-layers in vertex detector. This creates a mismatch when extracting layer parameters in realistic digitization which stores the layer information in an array with uniformly-numbered layers [here](https://github.com/MuonColliderSoft/MuonCVXDDigitiser/blob/master/src/MuonCVXDDigitiser.cc#L268). Hence, ionization points from simhits of some layers are never reconstructed (mis-reconstructed) due to missing (incorrect) layer information.